### PR TITLE
Use GNU Readline if it's available

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -91,6 +91,7 @@ os_based_configure_options() {
 
     local openssl_path=$(homebrew_package_path openssl)
     local libyaml_path=$(homebrew_package_path libyaml)
+    local readline_path=$(homebrew_package_path readline)
   else
     local openssl_path=/usr
     local libyaml_path=/usr
@@ -106,6 +107,10 @@ os_based_configure_options() {
     export ASDF_PKG_MISSING="$ASDF_PKG_MISSING libyaml"
   else
     configure_options="$configure_options --with-libyaml-dir=$libyaml_path"
+  fi
+
+  if [ "$readline_path" != "" ]; then
+    configure_options="$configure_options --with-readline-dir=$readline_path"
   fi
 
   configure_options="$configure_options --enable-shared --disable-install-doc"


### PR DESCRIPTION
A couple of popular Gems (Pry, Guard) do not function properly without using GNU readline (e.g. [this GitHub Issue](https://github.com/guard/guard/wiki/Add-Readline-support-to-Ruby-on-Mac-OS-X)).

This patch checks to see if GNU Readline has been installed via Homebrew on the Mac OS X and adds the proper `configure` argument. I don't *think* this is an issue on Linux because GNU Readline seems to be the default there.

I don't think it's worthwhile to make this a required Homebrew package like libyaml and libssl, but it certainly could be. For what it's worth, `ruby-build` takes this same approach of optionally using readline if it's installed.